### PR TITLE
Fix casing of MongoDB in logs and status message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/venv
 .idea
 build
 *.charm

--- a/src/charm.py
+++ b/src/charm.py
@@ -237,9 +237,9 @@ class GraylogCharm(CharmBase):
 
         # make sure we have a valid mongo and elasticsearch relation
         if not self.has_mongodb or not self.has_elasticsearch:
-            logger.warning('Need both mongodb and Elasticsearch relation for '
+            logger.warning('Need both MongoDB and Elasticsearch relation for '
                            'Graylog to function properly. Blocking.')
-            self.unit.status = BlockedStatus('Need mongodb and Elasticsearch relations.')
+            self.unit.status = BlockedStatus('Need MongoDB and Elasticsearch relations.')
             return
 
         spec = self._build_pod_spec()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -92,7 +92,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
         with self.assertLogs(level='WARNING') as logger:
             self.harness.update_config(BASE_CONFIG)
-            msg = 'WARNING:charm:Need both mongodb and Elasticsearch ' \
+            msg = 'WARNING:charm:Need both MongoDB and Elasticsearch ' \
                   'relation for Graylog to function properly. Blocking.'
             self.assertEqual(sorted(logger.output), [msg])
 


### PR DESCRIPTION
Fix casing of MongoDB in logs and status message. Since we say "Elasticsearch" it seems better to say "MongoDB" than "mongodb".